### PR TITLE
[Fix] Expose disk cache byte/age limits to PINCache initializer

### DIFF
--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -139,6 +139,30 @@ PIN_SUBCLASSING_RESTRICTED
  @param keyEncoder A block used to encode key(filename). If nil provided, default url encoder will be used
  @param keyDecoder A block used to decode key(filename). If nil provided, default url decoder will be used
  @param ttlCache Whether or not the cache should behave as a TTL cache.
+ @result A new cache with the specified name.
+ */
+- (instancetype)initWithName:(nonnull NSString *)name
+                    rootPath:(nonnull NSString *)rootPath
+                  serializer:(nullable PINDiskCacheSerializerBlock)serializer
+                deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
+                  keyEncoder:(nullable PINDiskCacheKeyEncoderBlock)keyEncoder
+                  keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyDecoder
+                    ttlCache:(BOOL)ttlCache;
+
+/**
+ Multiple instances with the same name are *not* allowed and can *not* safely
+ access the same data on disk. Also used to create the <diskCache>.
+ Initializer allows you to override default NSKeyedArchiver/NSKeyedUnarchiver serialization for <diskCache>.
+ You must provide both serializer and deserializer, or opt-out to default implementation providing nil values.
+ 
+ @see name
+ @param name The name of the cache.
+ @param rootPath The path of the cache on disk.
+ @param serializer   A block used to serialize object before writing to disk. If nil provided, default NSKeyedArchiver serialized will be used.
+ @param deserializer A block used to deserialize object read from disk. If nil provided, default NSKeyedUnarchiver serialized will be used.
+ @param keyEncoder A block used to encode key(filename). If nil provided, default url encoder will be used
+ @param keyDecoder A block used to decode key(filename). If nil provided, default url decoder will be used
+ @param ttlCache Whether or not the cache should behave as a TTL cache.
  @param byteLimit The maximum number of bytes allowed on disk. Defaults to 50MB.
  @param ageLimit The maximum number of seconds an object is allowed to exist in the cache. Defaults to 30 days.
  @result A new cache with the specified name.

--- a/Source/PINCache.h
+++ b/Source/PINCache.h
@@ -139,6 +139,8 @@ PIN_SUBCLASSING_RESTRICTED
  @param keyEncoder A block used to encode key(filename). If nil provided, default url encoder will be used
  @param keyDecoder A block used to decode key(filename). If nil provided, default url decoder will be used
  @param ttlCache Whether or not the cache should behave as a TTL cache.
+ @param byteLimit The maximum number of bytes allowed on disk. Defaults to 50MB.
+ @param ageLimit The maximum number of seconds an object is allowed to exist in the cache. Defaults to 30 days.
  @result A new cache with the specified name.
  */
 - (instancetype)initWithName:(nonnull NSString *)name
@@ -147,7 +149,9 @@ PIN_SUBCLASSING_RESTRICTED
                 deserializer:(nullable PINDiskCacheDeserializerBlock)deserializer
                   keyEncoder:(nullable PINDiskCacheKeyEncoderBlock)keyEncoder
                   keyDecoder:(nullable PINDiskCacheKeyDecoderBlock)keyDecoder
-                    ttlCache:(BOOL)ttlCache NS_DESIGNATED_INITIALIZER;
+                    ttlCache:(BOOL)ttlCache
+                   byteLimit:(NSUInteger)byteLimit
+                    ageLimit:(NSTimeInterval)ageLimit NS_DESIGNATED_INITIALIZER;
 
 @end
 

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -49,6 +49,17 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                   keyEncoder:(PINDiskCacheKeyEncoderBlock)keyEncoder
                   keyDecoder:(PINDiskCacheKeyDecoderBlock)keyDecoder
 {
+    return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer keyEncoder:keyEncoder keyDecoder:keyDecoder ttlCache:NO];
+}
+
+- (instancetype)initWithName:(NSString *)name
+                    rootPath:(NSString *)rootPath
+                  serializer:(PINDiskCacheSerializerBlock)serializer
+                deserializer:(PINDiskCacheDeserializerBlock)deserializer
+                  keyEncoder:(PINDiskCacheKeyEncoderBlock)keyEncoder
+                  keyDecoder:(PINDiskCacheKeyDecoderBlock)keyDecoder
+                    ttlCache:(BOOL)ttlCache
+{
     return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer keyEncoder:keyEncoder keyDecoder:keyDecoder ttlCache:NO
                     byteLimit:50 * 1024 * 1024 // 50 MB by default
                      ageLimit:60 * 60 * 24 * 30]; // 30 days by default

--- a/Source/PINCache.m
+++ b/Source/PINCache.m
@@ -49,7 +49,9 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                   keyEncoder:(PINDiskCacheKeyEncoderBlock)keyEncoder
                   keyDecoder:(PINDiskCacheKeyDecoderBlock)keyDecoder
 {
-    return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer keyEncoder:keyEncoder keyDecoder:keyDecoder ttlCache:NO];
+    return [self initWithName:name rootPath:rootPath serializer:serializer deserializer:deserializer keyEncoder:keyEncoder keyDecoder:keyDecoder ttlCache:NO
+                    byteLimit:50 * 1024 * 1024 // 50 MB by default
+                     ageLimit:60 * 60 * 24 * 30]; // 30 days by default
 }
 
 - (instancetype)initWithName:(NSString *)name
@@ -59,6 +61,8 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                   keyEncoder:(PINDiskCacheKeyEncoderBlock)keyEncoder
                   keyDecoder:(PINDiskCacheKeyDecoderBlock)keyDecoder
                     ttlCache:(BOOL)ttlCache
+                   byteLimit:(NSUInteger)byteLimit
+                    ageLimit:(NSTimeInterval)ageLimit
 {
     if (!name)
         return nil;
@@ -76,7 +80,9 @@ static NSString * const PINCacheSharedName = @"PINCacheShared";
                                              keyEncoder:keyEncoder
                                              keyDecoder:keyDecoder
                                          operationQueue:_operationQueue
-                                               ttlCache:ttlCache];
+                                               ttlCache:ttlCache
+                                              byteLimit:byteLimit
+                                               ageLimit:ageLimit];
         _memoryCache = [[PINMemoryCache alloc] initWithName:_name operationQueue:_operationQueue ttlCache:ttlCache];
     }
     return self;


### PR DESCRIPTION
## What this does
* Expose disk cache byte/age limits via `PINCache` initializer. This allows configuration of these `PINDiskCache` properties when a `PINCache` wrapper object is initialized to address https://github.com/pinterest/PINCache/pull/312.

## Tech debt
* N/A

## How I tested it
* Tested `PINCache` construction with different byte/age limits settings and verified that `self->_ageLimit` and `self->_byteLimit` were properly set in `initializeDiskProperties`

## What it looks like
* No UX changes
